### PR TITLE
zk里面配置值有空格引发异常

### DIFF
--- a/disconf-web/src/main/java/com/baidu/disconf/web/service/config/service/impl/ConfigMgrImpl.java
+++ b/disconf-web/src/main/java/com/baidu/disconf/web/service/config/service/impl/ConfigMgrImpl.java
@@ -318,7 +318,8 @@ public class ConfigMgrImpl implements ConfigMgr {
                     errorKeyList.add(keyInZk);
 
                 } else {
-
+                    
+                    zkDataStr = zkDataStr.trim();
                     boolean isEqual = true;
 
                     if (MyStringUtils.isDouble(zkDataStr) && MyStringUtils.isDouble(valueInDb.toString())) {


### PR DESCRIPTION
使用properties文件时候，如果有配置值有空格，zk里面存放的对应json值也有空格,web端出现显示服务出现错误   
错误信息类似   > **jndi.factory.url.pkgs	[[position: 0, size: 1, lines: [org.jboss.naming]]]**