### PR TITLE
enable_local_download_dir_in_class_path设置为false时出现bug

### DIFF
--- a/disconf-client/src/main/java/com/baidu/disconf/client/core/processor/impl/DisconfFileCoreProcessorImpl.java
+++ b/disconf-client/src/main/java/com/baidu/disconf/client/core/processor/impl/DisconfFileCoreProcessorImpl.java
@@ -1,5 +1,6 @@
 package com.baidu.disconf.client.core.processor.impl;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -121,7 +122,8 @@ public class DisconfFileCoreProcessorImpl implements DisconfCoreProcessor {
 
         try {
             dataMap = FileTypeProcessorUtils.getKvMap(disconfCenterFile.getSupportFileTypeEnum(),
-                    disconfCenterFile.getFilePath());
+                    DisClientConfig.getInstance().enableLocalDownloadDirInClassPath ? disconfCenterFile.getFilePath()
+                            : DisClientConfig.getInstance().userDefineDownloadDir + File.separator + fileName);
         } catch (Exception e) {
             LOGGER.error("cannot get kv data for " + filePath, e);
         }


### PR DESCRIPTION
enable_local_download_dir_in_class_path设置为false，读取到的是claspath路径
DisconfPropertiesProcessorImpl里面的properties = ConfigLoaderUtils.loadConfig(fileName)找不到文件出现异常