### PR TITLE
配置内容从数据库中取出返回给client时从unicode转回utf8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /.DS_Store
 /*-baidu.xml
 /log
+pom.xml
 .idea
 BCLOUD
 build.sh

--- a/disconf-web/src/main/java/com/baidu/disconf/web/service/config/bo/Config.java
+++ b/disconf-web/src/main/java/com/baidu/disconf/web/service/config/bo/Config.java
@@ -75,4 +75,79 @@ public class Config extends BaseObject<Long> {
     @Column(value = Columns.UPDATE_TIME)
     private String updateTime;
 
+    public static long getSerialVersionUID() {
+        return serialVersionUID;
+    }
+
+    public Integer getType() {
+        return type;
+    }
+
+    public void setType(Integer type) {
+        this.type = type;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public Long getAppId() {
+        return appId;
+    }
+
+    public void setAppId(Long appId) {
+        this.appId = appId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public Long getEnvId() {
+        return envId;
+    }
+
+    public void setEnvId(Long envId) {
+        this.envId = envId;
+    }
+
+    public String getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(String createTime) {
+        this.createTime = createTime;
+    }
+
+    public String getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(String updateTime) {
+        this.updateTime = updateTime;
+    }
 }

--- a/disconf-web/src/main/java/com/baidu/disconf/web/service/config/form/ConfListForm.java
+++ b/disconf-web/src/main/java/com/baidu/disconf/web/service/config/form/ConfListForm.java
@@ -1,10 +1,9 @@
 package com.baidu.disconf.web.service.config.form;
 
-import javax.validation.constraints.NotNull;
-
 import com.baidu.dsp.common.form.RequestListBase;
-
 import lombok.Data;
+
+import javax.validation.constraints.NotNull;
 
 /**
  * @author liaoqiqi
@@ -27,4 +26,27 @@ public class ConfListForm extends RequestListBase {
     @NotNull
     private Long envId;
 
+    public Long getAppId() {
+        return appId;
+    }
+
+    public void setAppId(Long appId) {
+        this.appId = appId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public Long getEnvId() {
+        return envId;
+    }
+
+    public void setEnvId(Long envId) {
+        this.envId = envId;
+    }
 }

--- a/disconf-web/src/main/java/com/baidu/disconf/web/service/config/service/impl/ConfigFetchMgrImpl.java
+++ b/disconf-web/src/main/java/com/baidu/disconf/web/service/config/service/impl/ConfigFetchMgrImpl.java
@@ -1,5 +1,6 @@
 package com.baidu.disconf.web.service.config.service.impl;
 
+import com.baidu.disconf.web.utils.CodeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +33,7 @@ public class ConfigFetchMgrImpl implements ConfigFetchMgr {
                                      DisConfigTypeEnum disConfigTypeEnum) {
 
         Config config = configDao.getByParameter(appId, envId, env, key, disConfigTypeEnum);
+        config.setValue(CodeUtils.unicodeToUtf8(config.getValue()));
         return config;
     }
 
@@ -44,6 +46,7 @@ public class ConfigFetchMgrImpl implements ConfigFetchMgr {
         if (config == null) {
             return ConfigUtils.getErrorVo("cannot find this config");
         }
+        config.setValue(CodeUtils.unicodeToUtf8(config.getValue()));
 
         ValueVo valueVo = new ValueVo();
         valueVo.setValue(config.getValue());

--- a/disconf-web/src/main/java/com/baidu/disconf/web/service/config/service/impl/ConfigMgrImpl.java
+++ b/disconf-web/src/main/java/com/baidu/disconf/web/service/config/service/impl/ConfigMgrImpl.java
@@ -1,24 +1,5 @@
 package com.baidu.disconf.web.service.config.service.impl;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringEscapeUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.baidu.disconf.core.common.constants.DisConfigTypeEnum;
 import com.baidu.disconf.web.common.Constants;
 import com.baidu.disconf.web.config.ApplicationPropertyConfig;
@@ -49,6 +30,19 @@ import com.baidu.ub.common.db.DaoPageResult;
 import com.github.knightliao.apollo.utils.data.GsonUtils;
 import com.github.knightliao.apollo.utils.io.OsUtil;
 import com.github.knightliao.apollo.utils.time.DateUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
 
 /**
  * @author liaoqiqi
@@ -127,7 +121,7 @@ public class ConfigMgrImpl implements ConfigMgr {
 
                 File file = new File(curTime, config.getName());
                 try {
-                    FileUtils.writeByteArrayToFile(file, config.getValue().getBytes());
+                    FileUtils.writeByteArrayToFile(file, CodeUtils.unicodeToUtf8(config.getValue()).getBytes());
                 } catch (IOException e) {
                     LOG.warn(e.toString());
                 }
@@ -496,7 +490,7 @@ public class ConfigMgrImpl implements ConfigMgr {
      */
     @Override
     public String getValue(Long configId) {
-        return configDao.getValue(configId);
+        return CodeUtils.unicodeToUtf8(configDao.getValue(configId));
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <modules>
         <module>disconf-client</module>
         <module>disconf-core</module>
+        <module>disconf-web</module>
     </modules>
 
     <inceptionYear>2015</inceptionYear>


### PR DESCRIPTION
从disconf-web下载配置文件和配置项时，应该把Unicode重新转成utf8返回，否则会导致disconf-client拿到的中文配置项显示有问题。顺便提交了两个javabean缺失的get、set方法。