### PR TITLE
指定只copy properties 文件

### DIFF
--- a/disconf-web/deploy/deploy.sh
+++ b/disconf-web/deploy/deploy.sh
@@ -48,7 +48,7 @@ if [ -d "src/main/online-resources" ]; then
     rm -rf src/main/online-resources/*
 fi
 mkdir -p src/main/online-resources
-cp -rp "$ONLINE_CONFIG_PATH"/* src/main/online-resources 
+cp -rp "$ONLINE_CONFIG_PATH"/*.properties src/main/online-resources 
 
 echo "**********************************************"
 echo "It's going to Generate the output for war"


### PR DESCRIPTION
如果把ONLINE_CONFIG_PATH指定为代码目录所在的某个目录，比如
    ONLINE_CONFIG_PATH=/home/me
    代码在/home/me/disconf/
那cp -r会在/home/me/disconf/disconf-web/deploy/src/main/online-resources生成文件，而-r会又一次拿到新文件，不断循环会造成死循环

要么这里改为cp properties，要么文档要写明ONLINE_CONFIG_PATH不能是代码的上一层目录