### PR TITLE
在Spring的org.springframework.context.support.PostProcessorRegistration…

### DIFF
--- a/disconf-client/src/main/java/com/baidu/disconf/client/addons/properties/ReloadingPropertyPlaceholderConfigurer.java
+++ b/disconf-client/src/main/java/com/baidu/disconf/client/addons/properties/ReloadingPropertyPlaceholderConfigurer.java
@@ -28,6 +28,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringValueResolver;
+import org.springframework.core.Ordered;
 
 /**
  * 具有 reloadable 的 property bean
@@ -48,6 +49,8 @@ public class ReloadingPropertyPlaceholderConfigurer extends DefaultPropertyPlace
     private String placeholderSuffix = DEFAULT_PLACEHOLDER_SUFFIX;
 
     private String beanName;
+
+    private int orderInSpringPostProcessors = Ordered.HIGHEST_PRECEDENCE;
 
     private BeanFactory beanFactory;
     private Properties[] propertiesArray;
@@ -511,5 +514,14 @@ public class ReloadingPropertyPlaceholderConfigurer extends DefaultPropertyPlace
     public void setBeanFactory(BeanFactory beanFactory) {
         this.beanFactory = beanFactory;
         super.setBeanFactory(beanFactory);
+    }
+
+    public void setOrderInSpringPostProcessors(int orderInSpringPostProcessors) {
+        this.orderInSpringPostProcessors = orderInSpringPostProcessors;
+    }
+
+    @Override
+    public int getOrder() {
+        return orderInSpringPostProcessors;
     }
 }


### PR DESCRIPTION
在Spring的`org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanFactoryPostProcessors`中可以看到包括`ReloadingPropertyPlaceholderConfigurer`在内的一些post processor会被排序然后再顺序调用。

在Spring boot环境中，如果按照`ReloadingPropertyPlaceholderConfigurer`从`org.springframework.beans.factory.config.PropertyResourceConfigurer`继承来的默认order是`Ordered.LOWEST_PRECEDENCE`，那么`ReloadingPropertyPlaceholderConfigurer`会排在Spring默认的`org.springframework.context.support.PropertySourcesPlaceholderConfigurer`后面。

如果一个key本来是要由`ReloadingPropertyPlaceholderConfigurer`托管的，但因为顺序在后，由Spring的`PropertySourcesPlaceholderConfigurer`先解析，而它无法找到一个Bean里面的@Value标注的key时会抛Exception。
通过提高`ReloadingPropertyPlaceholderConfigurer`的order（减小order值），可以让`ReloadingPropertyPlaceholderConfigurer`先解析key，如果不是disconf托管的，则留给`PropertySourcesPlaceholderConfigurer`去解析。

在Spring boot中测试，设成`Ordered.HIGHEST_PRECEDENCE`可以在Spring-Boot环境中以下面的配置支持disconf。

		<bean id="disconfMgrBean" class="com.baidu.disconf.client.DisconfMgrBean"
			destroy-method="destroy">
			<property name="scanPackage" value="com.mycompany" />
		</bean>
		<bean id="disconfMgrBean2" class="com.baidu.disconf.client.DisconfMgrBeanSecond"
			init-method="init" destroy-method="destroy">
		</bean>
		<!-- 使用托管方式的disconf配置(无代码侵入, 配置更改会自动reload) -->
		<bean id="configproperties_disconf"
			class="com.baidu.disconf.client.addons.properties.ReloadablePropertiesFactoryBean">
			<property name="locations">
				<list>
					<value>classpath:/cys-disconf-dev.properties</value>
				</list>
			</property>
		</bean>

		<bean id="propertyConfigurer"
			class="com.baidu.disconf.client.addons.properties.ReloadingPropertyPlaceholderConfigurer">
			<property name="ignoreResourceNotFound" value="true" />
			<property name="ignoreUnresolvablePlaceholders" value="true" />
			<property name="propertiesArray">
				<list>
					<ref bean="configproperties_disconf" />
				</list>
			</property>
		</bean>