### PR TITLE
[bugfix] CodeUtils::utf8ToUnicode对某些字符不能正确进行UTF8到Unicode转换

### DIFF
--- a/disconf-web/src/main/java/com/baidu/disconf/web/utils/CodeUtils.java
+++ b/disconf-web/src/main/java/com/baidu/disconf/web/utils/CodeUtils.java
@@ -53,8 +53,8 @@ public class CodeUtils {
         if (theString == null) {
             return null;
         }
-        char         aChar;
-        int          len       = theString.length();
+        char aChar;
+        int len = theString.length();
         StringBuffer outBuffer = new StringBuffer(len);
         for (int x = 0; x < len; ) {
             aChar = theString.charAt(x++);

--- a/disconf-web/src/main/java/com/baidu/disconf/web/utils/CodeUtils.java
+++ b/disconf-web/src/main/java/com/baidu/disconf/web/utils/CodeUtils.java
@@ -10,6 +10,8 @@ public class CodeUtils {
 
     protected static final Logger LOG = LoggerFactory.getLogger(CodeUtils.class);
 
+    private static final int SHIFT = 4;
+
     /**
      * utf-8 转换成 unicode
      */
@@ -26,10 +28,18 @@ public class CodeUtils {
                 int j = (int) myBuffer[i] - 65248;
                 sb.append((char) j);
             } else {
-                int chr1 = (char) myBuffer[i];
-                String hexS = Integer.toHexString(chr1);
-                String unicode = "\\u" + hexS;
-                sb.append(unicode.toLowerCase());
+                int chr1 = myBuffer[i] & 0x0FFFF;
+
+                //@see Integer::toUnsignedString0
+                int mag   = Integer.SIZE - Integer.numberOfLeadingZeros(chr1);
+                int chars = Math.max(((mag + (SHIFT - 1)) / SHIFT), 1);
+
+                StringBuilder builder = new StringBuilder("\\u");
+                for (int j = 0; j < SHIFT - chars; j++) {
+                    builder.append('0');
+                }
+                builder.append(Integer.toHexString(chr1));
+                sb.append(builder.toString().toLowerCase());
             }
         }
         return sb.toString();
@@ -43,8 +53,8 @@ public class CodeUtils {
         if (theString == null) {
             return null;
         }
-        char aChar;
-        int len = theString.length();
+        char         aChar;
+        int          len       = theString.length();
         StringBuffer outBuffer = new StringBuffer(len);
         for (int x = 0; x < len; ) {
             aChar = theString.charAt(x++);

--- a/disconf-web/src/test/java/com/baidu/disconf/web/test/utils/CodeUtilsTestCase.java
+++ b/disconf-web/src/test/java/com/baidu/disconf/web/test/utils/CodeUtilsTestCase.java
@@ -1,13 +1,14 @@
 package com.baidu.disconf.web.test.utils;
 
-import com.baidu.disconf.web.utils.CodeUtils;
+import java.io.File;
+import java.io.IOException;
+
 import org.apache.commons.io.FileUtils;
-import org.aspectj.apache.bcel.classfile.Code;
+
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.File;
-import java.io.IOException;
+import com.baidu.disconf.web.utils.CodeUtils;
 
 /**
  * Created by knightliao on 15/1/7.

--- a/disconf-web/src/test/java/com/baidu/disconf/web/test/utils/CodeUtilsTestCase.java
+++ b/disconf-web/src/test/java/com/baidu/disconf/web/test/utils/CodeUtilsTestCase.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.apache.commons.io.FileUtils;
-
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/disconf-web/src/test/java/com/baidu/disconf/web/test/utils/CodeUtilsTestCase.java
+++ b/disconf-web/src/test/java/com/baidu/disconf/web/test/utils/CodeUtilsTestCase.java
@@ -1,18 +1,32 @@
 package com.baidu.disconf.web.test.utils;
 
-import java.io.File;
-import java.io.IOException;
-
+import com.baidu.disconf.web.utils.CodeUtils;
 import org.apache.commons.io.FileUtils;
+import org.aspectj.apache.bcel.classfile.Code;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.baidu.disconf.web.utils.CodeUtils;
+import java.io.File;
+import java.io.IOException;
 
 /**
  * Created by knightliao on 15/1/7.
  */
 public class CodeUtilsTestCase {
+
+    @Test
+    public void utf8ToUnicodeTest() {
+        String code = CodeUtils.utf8ToUnicode("syserror.paramtype=请求参数解析错误");
+        System.out.println(code);
+        Assert.assertEquals("syserror.paramtype=\\u8bf7\\u6c42\\u53c2\\u6570\\u89e3\\u6790\\u9519\\u8bef", code);
+    }
+
+    @Test
+    public void utf8ToUnicodeTest2() {
+        String code = CodeUtils.utf8ToUnicode("·");
+        System.out.println(code);
+        Assert.assertEquals("\\u00b7", code);
+    }
 
     @Test
     public void unicodeToUtf8Test() {


### PR DESCRIPTION
如果chr1的高位是0，Integer.toHexString会出现丢失前导0的情况。
所以需要判断并补上丢失的0，再进行16进制转换

比如中文间隔号 · 转换结果是\ub7，正确结果是\u00b7