### PR TITLE
align commons-io version 1.4, 2.4 to 2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>1.4</version>
+                <version>2.4</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
align commons-io version to avoid inconsistent API behaviors.