### PR TITLE
fix(sec): upgrade org.springframework:spring-web to 5.3.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <java.version>1.7</java.version>
         <source.version>1.7</source.version>
         <target.version>1.7</target.version>
-        <spring.version>4.3.26.RELEASE</spring.version>
+        <spring.version>6.0.0</spring.version>
         <spring.amqp.version>1.4.5.RELEASE</spring.amqp.version>
         <junit.version>4.13.1</junit.version>
         <jsp.version>2.0</jsp.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-web 4.3.26.RELEASE
- [CVE-2020-5421](https://www.oscs1024.com/hd/CVE-2020-5421)


### What did I do？
Upgrade org.springframework:spring-web from 4.3.26.RELEASE to 5.3.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS